### PR TITLE
Set ets-dgiwg-core to v0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>org.opengis.cite</groupId>
       <artifactId>ets-dgiwg-core</artifactId>
-      <version>0.4</version>
+      <version>0.5</version>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
Can be merged as soon as ets-dgiwg-core v0.5 is released.